### PR TITLE
[Exsat] Add min transfer

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -741,7 +741,7 @@ void evm_contract::handle_evm_transfer(eosio::asset quantity, const std::string&
 
     //subtract off the ingress bridge fee from the quantity that will be bridged
     quantity -= _config->get_ingress_bridge_fee();
-    eosio::check(quantity.amount > 0, "must bridge more than ingress bridge fee");
+    eosio::check(quantity.amount >= 100, "must bridge more than ingress bridge fee plus 0.1");
 
     // Statistics
     auto s = get_statistics();

--- a/tests/admin_actions_tests.cpp
+++ b/tests/admin_actions_tests.cpp
@@ -306,9 +306,9 @@ BOOST_FIXTURE_TEST_CASE(addevmbal_subtract_tests, admin_action_tester) try {
    BOOST_REQUIRE_EXCEPTION(addevmbal(evm1_account.id, b100_plus_one, true),
          eosio_assert_message_exception, eosio_assert_message_is("decrementing more than available"));
 
-   // Fund evm2 address with 0.0001 EOS
+   // Fund evm2 address with 0.1 EOS
    evm_eoa evm2;
-   const int64_t to_bridge2 = 1;
+   const int64_t to_bridge2 = 1000;
    transfer_token("alice"_n, evm_account_name, make_asset(to_bridge2), evm2.address_0x());
    auto evm2_account = find_account_by_address(evm2.address).value();
 

--- a/tests/gas_param_tests.cpp
+++ b/tests/gas_param_tests.cpp
@@ -488,12 +488,12 @@ BOOST_FIXTURE_TEST_CASE(gas_limit_internal_transaction, gas_param_evm_tester) tr
     produce_block();
     produce_block();
 
-    // Send 0.0001 EOS to a never used address (21000 GAS)
+    // Send 0.1 EOS to a never used address (21000 GAS)
     evm_eoa evm1;
-    auto trace = transfer_token("alice"_n, "evm"_n, make_asset(1), evm1.address_0x());
+    auto trace = transfer_token("alice"_n, "evm"_n, make_asset(1000), evm1.address_0x());
     auto tx = get_tx_from_trace(trace->action_traces[3].act.data);
     BOOST_REQUIRE(tx.gas_limit == 21000);
-    BOOST_REQUIRE(evm_balance(evm1) == 100000000000000);
+    BOOST_REQUIRE(evm_balance(evm1) == 100000000000000000);
 
     // Set gas_txnewaccount = 1
     setgasparam(1, gas_newaccount, gas_txcreate, gas_codedeposit, gas_sset, evm_account_name);
@@ -501,12 +501,12 @@ BOOST_FIXTURE_TEST_CASE(gas_limit_internal_transaction, gas_param_evm_tester) tr
     produce_block();
     produce_block();
 
-    // Send 0.0001 EOS to a never used address (21001 GAS)
+    // Send 0.1 EOS to a never used address (21001 GAS)
     evm_eoa evm2;
-    trace = transfer_token("alice"_n, "evm"_n, make_asset(1), evm2.address_0x());
+    trace = transfer_token("alice"_n, "evm"_n, make_asset(1000), evm2.address_0x());
     tx = get_tx_from_trace(trace->action_traces[4].act.data);
     BOOST_REQUIRE(tx.gas_limit == 21001);
-    BOOST_REQUIRE(evm_balance(evm2) == 100000000000000);
+    BOOST_REQUIRE(evm_balance(evm2) == 100000000000000000);
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/native_token_tests.cpp
+++ b/tests/native_token_tests.cpp
@@ -277,14 +277,14 @@ BOOST_FIXTURE_TEST_CASE(basic_eos_evm_bridge, native_token_evm_tester_EOS) try {
    {
       const int64_t to_bridge = 900;
       BOOST_REQUIRE_EXCEPTION(transfer_token("alice"_n, "evm"_n, make_asset(to_bridge), evm1.address_0x()),
-                              eosio_assert_message_exception, eosio_assert_message_is("must bridge more than ingress bridge fee"));
+                              eosio_assert_message_exception, eosio_assert_message_is("must bridge more than ingress bridge fee plus 0.1"));
    }
 
    //transferring exact amount of bridge fee isn't allowed
    {
       const int64_t to_bridge = 1000;
       BOOST_REQUIRE_EXCEPTION(transfer_token("alice"_n, "evm"_n, make_asset(to_bridge), evm1.address_0x()),
-                              eosio_assert_message_exception, eosio_assert_message_is("must bridge more than ingress bridge fee"));
+                              eosio_assert_message_exception, eosio_assert_message_is("must bridge more than ingress bridge fee plus 0.1"));
    }
 
    BOOST_REQUIRE(expected_inevm == inevm());


### PR DESCRIPTION
The fix added to defend against some RAM consumption attack.

Maybe we will make this min value configurable in the future. For now, just fix number for easy management.