### PR TITLE
[Exsat] Support high stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ option(WITH_LOGTIME
 option(WITH_LARGE_STACK
    "Build with 50MB of stack size, needed for unit tests" OFF)
 
+option(WITH_LOW_STACK
+   "Build with low stack size, needed for network with default memory settings" OFF)
+
 option(WITH_ADMIN_ACTIONS
    "Enables admin actions" ON)
 
@@ -31,6 +34,7 @@ ExternalProject_Add(
               -DWITH_TEST_ACTIONS=${WITH_TEST_ACTIONS}
               -DWITH_LOGTIME=${WITH_LOGTIME}
               -DWITH_LARGE_STACK=${WITH_LARGE_STACK}
+              -DWITH_LOW_STACK=${WITH_LOW_STACK}
               -DWITH_ADMIN_ACTIONS=${WITH_ADMIN_ACTIONS}
               -DWITH_SOFT_FORKS=${WITH_SOFT_FORKS}
    UPDATE_COMMAND ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,8 +93,14 @@ target_include_directories( evm_runtime PUBLIC
 
 target_compile_options(evm_runtime PUBLIC --no-missing-ricardian-clause)
 
-if (WITH_LARGE_STACK)
+if (WITH_LARGE_STACK) 
+    # Limit for tests.
     target_link_options(evm_runtime PUBLIC --stack-size=50000000)
-else()
+elseif (WITH_LOW_STACK)
+    # Limit for Vaulta Networks with "default" memory settings.
     target_link_options(evm_runtime PUBLIC --stack-size=35984)
+else()
+    # Limit for Vaulta Networks with "high" memory settings. 
+    # It should be the default value for future deployments as the Vaulta Mainnet setting has been updated.
+    target_link_options(evm_runtime PUBLIC --stack-size=819200)
 endif()

--- a/tests/basic_evm_tester.cpp
+++ b/tests/basic_evm_tester.cpp
@@ -56,6 +56,54 @@ struct storage_table_row
    bytes value;
 };
 
+
+static const char wasm_level_up_wast[] = R"=====(
+(module
+ (import "env" "set_wasm_parameters_packed" (func $set_wasm_parameters_packed (param i32 i32)))
+ (memory $0 1)
+ (export "apply" (func $apply))
+ (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
+  (call $set_wasm_parameters_packed
+   (i32.const 0)
+   (i32.const 48)
+  )
+ )
+ ;; this is intended to be the same settings as used by eosio.system's 3.1.1 "high" setting
+ (data (i32.const 0)  "\00\00\00\00")     ;; version
+ (data (i32.const 4)  "\00\20\00\00")     ;; max_mutable_global_bytes
+ (data (i32.const 8)  "\00\20\00\00")     ;; max_table_elements
+ (data (i32.const 12) "\00\20\00\00")     ;; max_section_elements
+ (data (i32.const 16) "\00\00\10\00")     ;; max_linear_memory_init
+ (data (i32.const 20) "\00\20\00\00")     ;; max_func_local_bytes
+ (data (i32.const 24) "\00\04\00\00")     ;; max_nested_structures
+ (data (i32.const 28) "\00\20\00\00")     ;; max_symbol_bytes
+ (data (i32.const 32) "\00\00\40\01")     ;; max_module_bytes
+ (data (i32.const 36) "\00\00\40\01")     ;; max_code_bytes
+ (data (i32.const 40) "\10\02\00\00")     ;; max_pages
+ (data (i32.const 44) "\00\04\00\00")     ;; max_call_depth
+)
+)=====";
+
+static const char wasm_level_up_abi[] = R"=====(
+{
+   "version": "eosio::abi/1.2",
+   "types": [],
+   "structs": [
+      {
+         "name": "dothedew",
+         "base": "",
+         "fields": []
+      }
+   ],
+   "actions": [
+      {
+         "name": "dothedew",
+         "type": "dothedew"
+      }
+   ]
+}
+)=====";
+
 } // namespace evm_test
 
 namespace fc { namespace raw {
@@ -209,6 +257,15 @@ evmc::address basic_evm_tester::make_reserved_address(name account) {
 basic_evm_tester::basic_evm_tester(std::string native_symbol_str) :
    native_symbol(symbol::from_string(native_symbol_str))
 {
+   create_accounts({"wasmlevelup"_n});
+   push_action(config::system_account_name, "setpriv"_n, config::system_account_name, mvo()("account", "wasmlevelup"_n)("is_priv", 1));
+   produce_blocks(2);
+
+   set_code("wasmlevelup"_n, wasm_level_up_wast);
+   set_abi("wasmlevelup"_n, wasm_level_up_abi);
+   push_action("wasmlevelup"_n, "dothedew"_n, "wasmlevelup"_n, mvo());
+   produce_blocks(2);
+
    create_accounts({token_account_name, faucet_account_name, evm_account_name});
    produce_block();
 


### PR DESCRIPTION
After we relax the init_linear_memory limit in Vaulta, we can now use larger stack size.

This is vital to support higher level of CALLs and enable complicated contracts.